### PR TITLE
protect the DNS cache from entries that lack an Answer

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,26 @@
+name: 🔨 Build Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+
+jobs:  
+  build:
+    name: Test Builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Test
+        run: go test ./...
+
+      # Todo: create example folder
+      # - name: Build
+      #   run: go build .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,6 @@ name: 🚨 CodeQL Analysis
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
     branches:
       - dev
@@ -24,16 +23,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: latest
           args: --timeout 5m

--- a/fastdialer/dialer.go
+++ b/fastdialer/dialer.go
@@ -235,6 +235,9 @@ func (d *Dialer) dial(ctx context.Context, network, address string, shouldUseTLS
 					return nil, setErr
 				}
 			}
+			if d.options.OnDialCallback != nil {
+				d.options.OnDialCallback(hostname, ip)
+			}
 			if d.options.WithTLSData && shouldUseTLS {
 				if connTLS, ok := conn.(*tls.Conn); ok {
 					var data bytes.Buffer

--- a/fastdialer/dialer_test.go
+++ b/fastdialer/dialer_test.go
@@ -23,7 +23,8 @@ func TestDialer(t *testing.T) {
 	options.CacheType = Hybrid
 	options.CacheMemoryMaxItems = 100
 	testDialer(t, options)
-	testDialerIpv6(t, options)
+
+	// testDialerIpv6(t, options) not supported by GitHub VMs
 }
 
 func testDialer(t *testing.T, options Options) {
@@ -52,24 +53,25 @@ func testDialer(t *testing.T, options Options) {
 	fd.Close()
 }
 
+// nolint
 func testDialerIpv6(t *testing.T, options Options) {
 	// disk based
 	fd, err := NewDialer(options)
 	if err != nil {
-		t.Errorf("couldn't create fastdialer instance: %s", err)
+		t.Fatalf("couldn't create fastdialer instance: %s", err)
 	}
 
 	// valid resolution + cache
 	ctx := context.Background()
 	conn, err := fd.Dial(ctx, "tcp", "ipv6.google.com:80")
 	if err != nil || conn == nil {
-		t.Errorf("couldn't connect to target: %s", err)
+		t.Fatalf("couldn't connect to target: %s", err)
 	}
 	conn.Close()
 	// retrieve cached data
 	data, err := fd.GetDNSData("ipv6.google.com")
 	if err != nil || data == nil {
-		t.Errorf("couldn't retrieve dns data: %s", err)
+		t.Fatalf("couldn't retrieve dns data: %s", err)
 	}
 	if len(data.AAAA) == 0 {
 		t.Error("no AAAA results found")
@@ -79,11 +81,11 @@ func testDialerIpv6(t *testing.T, options Options) {
 	// this test passes, but will fail if the hard-coded ipv6 address changes
 	// need to find a better way to test this
 	/*
-	    conn, err = fd.Dial(ctx, "tcp", "ipv6.google.com:80:[2607:f8b0:4006:807::200e]")
-		if err != nil || conn == nil {
-			t.Errorf("couldn't connect to target: %s", err)
-		}
-		conn.Close()
+		    conn, err = fd.Dial(ctx, "tcp", "ipv6.google.com:80:[2607:f8b0:4006:807::200e]")
+			if err != nil || conn == nil {
+				t.Errorf("couldn't connect to target: %s", err)
+			}
+			conn.Close()
 	*/
 
 	// cleanup

--- a/fastdialer/options.go
+++ b/fastdialer/options.go
@@ -47,6 +47,7 @@ type Options struct {
 	Dialer              *net.Dialer
 	WithZTLS            bool
 	SNIName             string
+	OnDialCallback      func(hostname, IP string)
 }
 
 // DefaultOptions of the cache

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/projectdiscovery/networkpolicy v0.0.1
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20210916165024-76c5b76fd59a
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/stretchr/testify v1.7.4
+	github.com/stretchr/testify v1.8.0
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6
 	github.com/zmap/zcrypto v0.0.0-20211005224000-2d0ffdec8a9b
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/projectdiscovery/networkpolicy v0.0.1
 	github.com/projectdiscovery/retryabledns v1.0.13-0.20210916165024-76c5b76fd59a
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
-	github.com/stretchr/testify v1.7.2
+	github.com/stretchr/testify v1.7.4
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6
 	github.com/zmap/zcrypto v0.0.0-20211005224000-2d0ffdec8a9b
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,14 +111,16 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6 h1:TtyC78WMafNW8QFfv3TeP3yWNDG+uxNkk9vOrnDu6JA=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6 h1:TtyC78WMafNW8QFfv3TeP3yWNDG+uxNkk9vOrnDu6JA=


### PR DESCRIPTION
Two changes in this PR:

1. protect the DNS cache from entries that lack an Answer (explanation below)
2. add .gitignore to ignore vendor/ folder

In testing Nuclei as an embedded library in an AWS lambda (even worse, in a lambda being run in [localstack](https://github.com/localstack/localstack) container in docker-compose), with a bit of `fmt.Print*` to print the value of `b` here:

```
b, _ := data.Marshal()
err = d.hm.Set(hostname, b)
```

I observed that when passing both `https://something` and `http://something` into the executor with Nuclei configured for `BulkSize` greater than 1, the value of `b` occasionally _lacked_ an Answer, which would populate the cache with a bad entry.

I honestly don't know if it's due to odd behavior of docker-compose internal DNS, or a go bug or what, but the change in this PR adds some protection for the cache.

Related to this discussion:  https://github.com/projectdiscovery/nuclei/discussions/2277

**Detail:**

I added code like:

```
if b != nil {
    fmt.Printf("MIKE: b is %v\n", b)  // not string(b) because for some reason the lambda panicked
}
```

Then inspected the output to observe there was no `Answer` in the `b` passed to `d.hm.Set` in some cases.  I could _not_ reliably reproduce the problem, but it was frequent enough to warrant the investigation and this PR.