### PR TITLE
ztls fallback support and renegotiation error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Fastdialer is implementation of `net.Dialer` with lot of features like DNS Cache
 
 For more details and documentation refer [GoDoc](https://pkg.go.dev/github.com/projectdiscovery/fastdialer/fastdialer).
 
+
+### ZTLS Fallback
+
+fastdialer by default fallbacks to using zcrypto when there is an error in TLS handshake (insufficient security level etc ). This is done to support older TLS versions and ciphers. This can be disabled in fastdialer options or by using DISABLE_ZTLS_FALLBACK environment variable. when falling back to ztls, ChromeCiphers are used
+
 # Example
 
 An Example showing usage of fastdialer as a library is specified [here](./example/main.go)

--- a/fastdialer/options.go
+++ b/fastdialer/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	WithZTLS            bool
 	SNIName             string
 	OnDialCallback      func(hostname, IP string)
+	DisableZtlsFallback bool
 }
 
 // DefaultOptions of the cache


### PR DESCRIPTION
## Proposed Changes

- adds ztls fallback with chrome ciphers to resolve https://github.com/projectdiscovery/nuclei/issues/2805
- when using fastdialer.DialTLS `renegotiation` was not set which caused https://github.com/projectdiscovery/nuclei/issues/3553 in nuclei


### Notes

suggesting deprecating and removing `-ztls` mode in nuclei . ZTLS currently does not support TLS1.3 as well as `Renogotiation`. using fastdialer in this PR with nuclei shows using ztls mode by default causes host to skip since it does not support renogotiation

## Setup
checkout nuclei from  https://github.com/projectdiscovery/nuclei/pull/3909 which contains fastdialer from this PR

### using nuclei with ztls mode

```console
$  echo "https://moh.gov.sy" | go run . -v -id tech-detect -nh -ztls

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.8

		projectdiscovery.io

[INF] Current nuclei version: v2.9.8 (latest)
[INF] Current nuclei-templates version: v9.5.4 (latest)
[INF] New templates added in latest release: 51
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[WRN] [tech-detect] Could not execute request for https://moh.gov.sy: GET https://moh.gov.sy giving up after 2 attempts: Get "https://moh.gov.sy": local error: no renegotiation
[INF] No results found. Better luck next time!

```

### using nuclei without ztls mode (i.e implicit ztls fallback)

```console
$ echo "https://moh.gov.sy" | go run . -v -id tech-detect -nh      

                     __     _
   ____  __  _______/ /__  (_)
  / __ \/ / / / ___/ / _ \/ /
 / / / / /_/ / /__/ /  __/ /
/_/ /_/\__,_/\___/_/\___/_/   v2.9.8

		projectdiscovery.io

[INF] Current nuclei version: v2.9.8 (latest)
[INF] Current nuclei-templates version: v9.5.4 (latest)
[INF] New templates added in latest release: 51
[INF] Templates loaded for current scan: 1
[INF] Targets loaded for current scan: 1
[VER] [tech-detect] Sent HTTP request to https://moh.gov.sy
[tech-detect:ms-iis] [http] [info] https://moh.gov.sy/
[tech-detect:ms-iis] [http] [info] https://moh.gov.sy/Default.aspx?tabid=704&language=en-US
[tech-detect:ms-iis] [http] [info] https://moh.gov.sy
```

- unless we have a reason to explicitly keep `-ztls` flag i think we should remove it since its use cases are covered and sometimes using it causes issues 