### PR TITLE
fix memory leaks

### DIFF
--- a/fastdialer/metafiles/doc.go
+++ b/fastdialer/metafiles/doc.go
@@ -1,0 +1,3 @@
+// metafiles are metadata files related to networking like
+// /etc/hosts etc
+package metafiles

--- a/fastdialer/metafiles/hostsfile_unix.go
+++ b/fastdialer/metafiles/hostsfile_unix.go
@@ -1,6 +1,7 @@
+//go:build !windows
 // +build !windows
 
-package fastdialer
+package metafiles
 
 // HostsFilePath in unix file os
 const HostsFilePath = "/etc/hosts"

--- a/fastdialer/metafiles/hostsfile_windows.go
+++ b/fastdialer/metafiles/hostsfile_windows.go
@@ -1,5 +1,6 @@
+//go:build windows
 // +build windows
 
-package fastdialer
+package metafiles
 
 const HostsFilePath = "${SystemRoot}/System32/drivers/etc/hosts"

--- a/fastdialer/metafiles/shared.go
+++ b/fastdialer/metafiles/shared.go
@@ -1,0 +1,89 @@
+package metafiles
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/projectdiscovery/hmap/store/hybrid"
+	"github.com/projectdiscovery/utils/env"
+)
+
+type StorageType int
+
+const (
+	InMemory StorageType = iota
+	Hybrid
+)
+
+var (
+	MaxHostsEntires = 4096
+	// LoadAllEntries is a switch when true loads all entries to hybrid storage
+	// backend and uses it even if in-memory storage backend was requested
+	LoadAllEntries = false
+)
+
+func init() {
+	MaxHostsEntires = env.GetEnvOrDefault("HF_MAX_HOSTS", 4096)
+	LoadAllEntries = env.GetEnvOrDefault("HF_LOAD_ALL", false)
+}
+
+// GetHostsFileDnsData returns the immutable dns data that is constant throughout the program
+// lifecycle and shouldn't be purged by cache etc.
+func GetHostsFileDnsData(storage StorageType) (*hybrid.HybridMap, error) {
+	if LoadAllEntries {
+		storage = Hybrid
+	}
+	switch storage {
+	case InMemory:
+		return getHFInMemory()
+	case Hybrid:
+		return getHFHybridStorage()
+	}
+	return nil, nil
+}
+
+var hostsMemOnce = &sync.Once{}
+
+// getImm
+func getHFInMemory() (*hybrid.HybridMap, error) {
+	var hm *hybrid.HybridMap
+	var err error
+	hostsMemOnce.Do(func() {
+		opts := hybrid.DefaultMemoryOptions
+		hm, err = hybrid.New(opts)
+		if err != nil {
+			return
+		}
+		err = loadHostsFile(hm, MaxHostsEntires)
+		if err != nil {
+			hm.Close()
+			return
+		}
+	})
+	return hm, nil
+}
+
+var hostsHybridOnce = &sync.Once{}
+
+func getHFHybridStorage() (*hybrid.HybridMap, error) {
+	var hm *hybrid.HybridMap
+	var err error
+	hostsHybridOnce.Do(func() {
+		opts := hybrid.DefaultHybridOptions
+		opts.Cleanup = true
+		hm, err = hybrid.New(opts)
+		if err != nil {
+			return
+		}
+		err = loadHostsFile(hm, -1)
+		if err != nil {
+			hm.Close()
+			return
+		}
+		// set finalizer for cleanup
+		runtime.SetFinalizer(hm, func(hm *hybrid.HybridMap) {
+			_ = hm.Close()
+		})
+	})
+	return hm, nil
+}

--- a/fastdialer/resolverfile.go
+++ b/fastdialer/resolverfile.go
@@ -9,7 +9,17 @@ import (
 
 	"github.com/dimchansky/utfbom"
 	"github.com/projectdiscovery/fastdialer/fastdialer/metafiles"
+	"github.com/projectdiscovery/utils/env"
 )
+
+var (
+	MaxResolverEntries = 4096
+)
+
+func init() {
+	// use -1 for all entries
+	MaxResolverEntries = env.GetEnvOrDefault("MAX_RESOLVERS", 4096)
+}
 
 func loadResolverFile() ([]string, error) {
 	osResolversFilePath := os.ExpandEnv(filepath.FromSlash(ResolverFilePath))
@@ -28,6 +38,9 @@ func loadResolverFile() ([]string, error) {
 
 	scanner := bufio.NewScanner(utfbom.SkipOnly(file))
 	for scanner.Scan() {
+		if MaxResolverEntries != -1 && len(systemResolvers) >= MaxResolverEntries {
+			break
+		}
 		resolverIP := HandleResolverLine(scanner.Text())
 		if resolverIP == "" {
 			continue

--- a/fastdialer/resolverfile.go
+++ b/fastdialer/resolverfile.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/dimchansky/utfbom"
+	"github.com/projectdiscovery/fastdialer/fastdialer/metafiles"
 )
 
 func loadResolverFile() ([]string, error) {
@@ -39,13 +40,13 @@ func loadResolverFile() ([]string, error) {
 // HandleLine a resolver file line
 func HandleResolverLine(raw string) (ip string) {
 	// ignore comment
-	if IsComment(raw) {
+	if metafiles.IsComment(raw) {
 		return
 	}
 
 	// trim comment
-	if HasComment(raw) {
-		commentSplit := strings.Split(raw, commentChar)
+	if metafiles.HasComment(raw) {
+		commentSplit := strings.Split(raw, metafiles.CommentChar)
 		raw = commentSplit[0]
 	}
 


### PR DESCRIPTION
### Context

- Due to improper config or changes in config or someother scenario multiple fastdialer are created on demand 
- Every time new instance of fastdialer is created all entries are load from hosts file and stored in selected storage backend 
- in retryablehttp-go we were using fastdialer memory backend and multiple calls due to different scenarios caused hosts file to be loaded multiple lines (and if hosts file is large it caused a mem leak/over consumption of memory and crash nuclei or cause init to take too long (see: https://github.com/projectdiscovery/nuclei/issues/4632 )
- ref: https://github.com/projectdiscovery/retryablehttp-go/pull/198

### Proposed Changes
- seperate host file and dns cache logic 
- make hostsfile hmap shared /global and is initialized on demand 
- finalizer cleans up any temporary files created by hmap in hybrid mode
- add env vars to tweak behaviour
```console
MAX_DNS_CACHE_SIZE=10MB # current default
HF_MAX_HOSTS=4096 # hosts file max hosts to load in memory
HF_LOAD_ALL=false # when true uses hybrid backend instead and loads all entries from hosts file
```
- added max dns cache size on memory backend
- now we use either memory or hybrid backend for dns cache / hostsFile data

