### PR TITLE
fix hostfile hybridmap reuse

### DIFF
--- a/fastdialer/dialer.go
+++ b/fastdialer/dialer.go
@@ -223,6 +223,11 @@ func (d *Dialer) DialZTLSWithConfig(ctx context.Context, network, address string
 }
 
 func (d *Dialer) dial(ctx context.Context, network, address string, shouldUseTLS, shouldUseZTLS bool, tlsconfig *tls.Config, ztlsconfig *ztls.Config, impersonateStrategy impersonate.Strategy, impersonateIdentity *impersonate.Identity) (conn net.Conn, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
 	var hostname, port, fixedIP string
 
 	if strings.HasPrefix(address, "[") {

--- a/fastdialer/dialer.go
+++ b/fastdialer/dialer.go
@@ -133,8 +133,8 @@ func NewDialer(options Options) (*Dialer, error) {
 		} else {
 			hostsFileData, err = metafiles.GetHostsFileDnsData(metafiles.Hybrid)
 		}
-		if err != nil {
-			return nil, err
+		if options.Logger != nil && err != nil {
+			options.Logger.Printf("could not load hosts file: %s\n", err)
 		}
 	}
 	dnsclient, err := retryabledns.New(resolvers, options.MaxRetries)

--- a/fastdialer/dialer.go
+++ b/fastdialer/dialer.go
@@ -127,10 +127,14 @@ func NewDialer(options Options) (*Dialer, error) {
 	var hostsFileData *hybrid.HybridMap
 	// load hardcoded values from host file
 	if options.HostsFile {
+		var err error
 		if options.CacheType == Memory {
-			hostsFileData, _ = metafiles.GetHostsFileDnsData(metafiles.InMemory)
+			hostsFileData, err = metafiles.GetHostsFileDnsData(metafiles.InMemory)
 		} else {
-			hostsFileData, _ = metafiles.GetHostsFileDnsData(metafiles.Hybrid)
+			hostsFileData, err = metafiles.GetHostsFileDnsData(metafiles.Hybrid)
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	dnsclient, err := retryabledns.New(resolvers, options.MaxRetries)

--- a/fastdialer/dialer_test.go
+++ b/fastdialer/dialer_test.go
@@ -53,41 +53,41 @@ func testDialer(t *testing.T, options Options) {
 	fd.Close()
 }
 
-// nolint
-func testDialerIpv6(t *testing.T, options Options) {
-	// disk based
-	fd, err := NewDialer(options)
-	if err != nil {
-		t.Fatalf("couldn't create fastdialer instance: %s", err)
-	}
+// // nolint
+// func testDialerIpv6(t *testing.T, options Options) {
+// 	// disk based
+// 	fd, err := NewDialer(options)
+// 	if err != nil {
+// 		t.Fatalf("couldn't create fastdialer instance: %s", err)
+// 	}
 
-	// valid resolution + cache
-	ctx := context.Background()
-	conn, err := fd.Dial(ctx, "tcp", "ipv6.google.com:80")
-	if err != nil || conn == nil {
-		t.Fatalf("couldn't connect to target: %s", err)
-	}
-	conn.Close()
-	// retrieve cached data
-	data, err := fd.GetDNSData("ipv6.google.com")
-	if err != nil || data == nil {
-		t.Fatalf("couldn't retrieve dns data: %s", err)
-	}
-	if len(data.AAAA) == 0 {
-		t.Error("no AAAA results found")
-	}
+// 	// valid resolution + cache
+// 	ctx := context.Background()
+// 	conn, err := fd.Dial(ctx, "tcp", "ipv6.google.com:80")
+// 	if err != nil || conn == nil {
+// 		t.Fatalf("couldn't connect to target: %s", err)
+// 	}
+// 	conn.Close()
+// 	// retrieve cached data
+// 	data, err := fd.GetDNSData("ipv6.google.com")
+// 	if err != nil || data == nil {
+// 		t.Fatalf("couldn't retrieve dns data: %s", err)
+// 	}
+// 	if len(data.AAAA) == 0 {
+// 		t.Error("no AAAA results found")
+// 	}
 
-	// test address pinning
-	// this test passes, but will fail if the hard-coded ipv6 address changes
-	// need to find a better way to test this
-	/*
-		    conn, err = fd.Dial(ctx, "tcp", "ipv6.google.com:80:[2607:f8b0:4006:807::200e]")
-			if err != nil || conn == nil {
-				t.Errorf("couldn't connect to target: %s", err)
-			}
-			conn.Close()
-	*/
+// 	// test address pinning
+// 	// this test passes, but will fail if the hard-coded ipv6 address changes
+// 	// need to find a better way to test this
+// 	/*
+// 		    conn, err = fd.Dial(ctx, "tcp", "ipv6.google.com:80:[2607:f8b0:4006:807::200e]")
+// 			if err != nil || conn == nil {
+// 				t.Errorf("couldn't connect to target: %s", err)
+// 			}
+// 			conn.Close()
+// 	*/
 
-	// cleanup
-	fd.Close()
-}
+// 	// cleanup
+// 	fd.Close()
+// }

--- a/fastdialer/options.go
+++ b/fastdialer/options.go
@@ -1,6 +1,7 @@
 package fastdialer
 
 import (
+	"log"
 	"net"
 	"time"
 
@@ -60,6 +61,7 @@ type Options struct {
 	OnDialCallback           func(hostname, IP string)
 	DisableZtlsFallback      bool
 	WithNetworkPolicyOptions *networkpolicy.Options
+	Logger                   *log.Logger // optional logger to log errors(like hostfile init error)
 }
 
 // DefaultOptions of the cache


### PR DESCRIPTION
### Proposed Changes

- during lazy initialization hm updated local variable instead global variable 
- which caused subsequent calls to return nil  instance with no /etc/hosts data
- closes #236 
- closes #248 