### PR TITLE
feat: add configurable connection cache expiry

### DIFF
--- a/fastdialer/dialer_private.go
+++ b/fastdialer/dialer_private.go
@@ -166,6 +166,7 @@ func (d *Dialer) dial(ctx context.Context, opts *dialOptions) (conn net.Conn, er
 		if err != nil {
 			return nil, errkit.Wrap(err, "could not create dialwrap")
 		}
+		dw.SetExpireConnAfter(d.options.ConnectionCacheExpiry)
 		if err = d.dialCache.Set(opts.connHash(), dw); err != nil {
 			return nil, errkit.Wrap(err, "could not set dialwrap")
 		}

--- a/fastdialer/options.go
+++ b/fastdialer/options.go
@@ -68,6 +68,12 @@ type Options struct {
 	// optional max temporary errors to mark as permanent
 	MaxTemporaryErrors              int
 	MaxTemporaryToPermanentDuration time.Duration
+
+	// ConnectionCacheExpiry is the duration after which a cached connection
+	// expires.
+	//
+	// Default is [DefaultConnExpiry].
+	ConnectionCacheExpiry time.Duration
 }
 
 // DefaultOptions of the cache


### PR DESCRIPTION
feat: add configurable connection cache expiry

Add `Options.ConnectionCacheExpiry` field to allow
configuring the duration after which cached conns
expire in `DialWrap`.

Prev, connection expiry was hardcoded to 5s via
the global `ExpireConnAfter` var. This change
introduces a new field in `Options` that allows
users to configure the expiry duration per `Dialer`
instance.

Changes:
* Add `ConnectionCacheExpiry` field to Options.
* Add `DefaultConnExpiry` const (10s) to replace
  hardcoded value.
* Deprecate `ExpireConnAfter` global var.
* Add `expireConnAfter` field to `DialWrap` struct.
* Init `DialWrap.expireConnAfter` to
  `DefaultConnExpiry`.
* Add `(*DialWrap).SetExpireConnAfter` method for
  runtime configuration.
* Call `SetExpireConnAfter` when creating `DialWrap`
  in `Dialer.dial()`
* Update `dialAllParallel` to use `expireConnAfter`
  instead of global variable.

The default expiry has been increased from 5s to
10s to better match typical conn lifetimes while
maintaining backward compat through the deprecated
variable.