### PR TITLE
feat!: add resolv.conf(5) `search` domains & `ndots` support

### DIFF
--- a/fastdialer/const.go
+++ b/fastdialer/const.go
@@ -1,0 +1,10 @@
+package fastdialer
+
+const (
+	// DefaultMaxResolverEntries is the default maximum number of resolver
+	// entries to read from the resolvers file.
+	DefaultMaxResolverEntries = 4096
+
+	// DefaultNdots is the default ndots value.
+	DefaultNdots = 1
+)

--- a/fastdialer/dialer.go
+++ b/fastdialer/dialer.go
@@ -87,6 +87,8 @@ type Dialer struct {
 	dialer            *net.Dialer
 	proxyDialer       *proxy.Dialer
 	networkpolicy     *networkpolicy.NetworkPolicy
+	searchDomains     []string
+	ndots             int
 	dialCache         gcache.Cache[string, *utils.DialWrap]
 	dialTimeoutErrors gcache.Cache[string, *atomic.Uint32]
 
@@ -96,11 +98,27 @@ type Dialer struct {
 // NewDialer instance
 func NewDialer(options Options) (*Dialer, error) {
 	var resolvers []string
+	var searchDomains []string
+	var ndots = options.Ndots
+	if ndots <= 0 {
+		ndots = DefaultNdots
+	}
+
 	// Add system resolvers as the first to be tried
 	if options.ResolversFile {
-		systemResolvers, err := loadResolverFile()
-		if err == nil && len(systemResolvers) > 0 {
-			resolvers = systemResolvers
+		systemConfig, err := loadResolverFile(options)
+		if err == nil && systemConfig != nil {
+			if len(systemConfig.Resolvers) > 0 {
+				resolvers = systemConfig.Resolvers
+			}
+
+			if len(systemConfig.SearchDomains) > 0 {
+				searchDomains = systemConfig.SearchDomains
+			}
+
+			if systemConfig.Ndots > 0 {
+				ndots = systemConfig.Ndots
+			}
 		}
 	}
 
@@ -194,6 +212,8 @@ func NewDialer(options Options) (*Dialer, error) {
 		proxyDialer:      options.ProxyDialer,
 		options:          &options,
 		networkpolicy:    np,
+		searchDomains:    searchDomains,
+		ndots:            ndots,
 		dialCache:        gcache.New[string, *utils.DialWrap](MaxDialCacheSize).Build(),
 		resolutionsGroup: &singleflight.Group{},
 	}
@@ -424,45 +444,118 @@ func (d *Dialer) GetDNSData(hostname string) (*retryabledns.DNSData, error) {
 			return &retryabledns.DNSData{AAAA: []string{hostname}}, nil
 		}
 	}
+
 	var (
 		data *retryabledns.DNSData
 		err  error
 	)
+
 	data, err = d.GetDNSDataFromCache(hostname)
-	if err != nil {
-		data, err = d.dnsclient.Resolve(hostname)
-		if err != nil && d.options.EnableFallback {
-			data, err = d.dnsclient.ResolveWithSyscall(hostname)
-		}
-		if err != nil {
-			return nil, err
-		}
-		if data == nil {
-			return nil, ResolveHostError
-		}
-		if len(data.A)+len(data.AAAA) > 0 {
-			if d.mDnsCache != nil {
-				err := d.mDnsCache.Set(hostname, data)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			if d.hmDnsCache != nil {
-				b, errX := data.Marshal()
-				if errX != nil {
-					return nil, errX
-				}
-				err := d.hmDnsCache.Set(hostname, b)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-		}
+	if err == nil {
 		return data, nil
 	}
+
+	data, err = d.resolveWithSearch(hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	if data == nil {
+		return nil, ResolveHostError
+	}
+
+	// normalize host to original input for caching/telemetry consistency.
+	data.Host = hostname
+
+	if len(data.A)+len(data.AAAA) > 0 {
+		if d.mDnsCache != nil {
+			if setErr := d.mDnsCache.Set(hostname, data); setErr != nil {
+				return nil, setErr
+			}
+		}
+
+		if d.hmDnsCache != nil {
+			b, errX := data.Marshal()
+			if errX != nil {
+				return nil, errX
+			}
+
+			if setErr := d.hmDnsCache.Set(hostname, b); setErr != nil {
+				return nil, setErr
+			}
+		}
+	}
+
 	return data, nil
+}
+
+// resolveWithSearch replicates resolv.conf search + ndots behavior before hitting DNS.
+func (d *Dialer) resolveWithSearch(hostname string) (*retryabledns.DNSData, error) {
+	// absolute names or trailing dot skip search-domain expansion.
+	if before, ok := strings.CutSuffix(hostname, "."); ok {
+		trimmed := before
+		return d.dnsclient.Resolve(trimmed)
+	}
+
+	dotCount := strings.Count(hostname, ".")
+	var candidates []string
+
+	seen := make(map[string]struct{})
+	addCandidate := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+
+		seen[name] = struct{}{}
+		candidates = append(candidates, name)
+	}
+
+	if dotCount >= d.ndots {
+		addCandidate(hostname)
+	}
+
+	for _, domain := range d.searchDomains {
+		domain = strings.TrimSuffix(domain, ".")
+		if domain == "" {
+			continue
+		}
+
+		candidate := hostname + "." + domain
+		addCandidate(candidate)
+	}
+
+	// final absolute attempt.
+	addCandidate(hostname)
+
+	var lastErr error
+	for _, name := range candidates {
+		data, err := d.dnsclient.Resolve(name)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if data != nil && (len(data.A) > 0 || len(data.AAAA) > 0) {
+			return data, nil
+		}
+
+		// if no A/AAAA but no error, keep trying other candidates.
+	}
+
+	if d.options.EnableFallback {
+		data, err := d.dnsclient.ResolveWithSyscall(hostname)
+		if err == nil {
+			return data, nil
+		}
+
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	return nil, ResolveHostError
 }
 
 var MaxDialerTimeout = time.Minute

--- a/fastdialer/options.go
+++ b/fastdialer/options.go
@@ -74,6 +74,20 @@ type Options struct {
 	//
 	// Default is [DefaultConnExpiry].
 	ConnectionCacheExpiry time.Duration
+
+	// MaxResolverEntries limits the number of resolvers read from the resolvers
+	// file.
+	//
+	// Default is [DefaultMaxResolverEntries].
+	// Use -1 for unlimited entries.
+	MaxResolverEntries int
+
+	// Ndots enforces the resolv.conf(5) ndots: threshold for treating a name
+	// as absolute before search domains are appended (see
+	// https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
+	//
+	// Default is [DefaultNdots].
+	Ndots int
 }
 
 // DefaultOptions of the cache

--- a/fastdialer/resolverfile.go
+++ b/fastdialer/resolverfile.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/dimchansky/utfbom"
@@ -13,16 +14,37 @@ import (
 )
 
 var (
+	// MaxResolverEntries limits the number of resolver entries parsed from
+	// resolver file.
+	//
+	// -1 means no limit.
+	//
+	// Deprecated: Use [DefaultMaxResolverEntries] instead. Adjust via [Options].
 	MaxResolverEntries = 4096
 )
 
-func init() {
-	// use -1 for all entries
-	MaxResolverEntries = env.GetEnvOrDefault("MAX_RESOLVERS", 4096)
+// ResolverConfig captures nameservers plus search-domain semantics from
+// resolv.conf(5).
+type ResolverConfig struct {
+	// Resolvers are the list of nameservers.
+	Resolvers []string
+
+	// SearchDomains are the search domains.
+	SearchDomains []string
+
+	// Ndots enforces the resolv.conf(5) ndots: threshold for treating a name
+	// as absolute before search domains are appended (see
+	// https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
+	Ndots int
 }
 
-func loadResolverFile() ([]string, error) {
+func loadResolverFile(opt Options) (*ResolverConfig, error) {
 	osResolversFilePath := os.ExpandEnv(filepath.FromSlash(ResolverFilePath))
+
+	maxResolverEntries := opt.MaxResolverEntries
+	if maxResolverEntries == 0 {
+		maxResolverEntries = env.GetEnvOrDefault("MAX_RESOLVERS", DefaultMaxResolverEntries)
+	}
 
 	if env, isset := os.LookupEnv("RESOLVERS_PATH"); isset && len(env) > 0 {
 		osResolversFilePath = os.ExpandEnv(filepath.FromSlash(env))
@@ -32,24 +54,71 @@ func loadResolverFile() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() {
 		_ = file.Close()
 	}()
 
-	var systemResolvers []string
-
+	config := &ResolverConfig{Ndots: opt.Ndots}
 	scanner := bufio.NewScanner(utfbom.SkipOnly(file))
+
 	for scanner.Scan() {
-		if MaxResolverEntries != -1 && len(systemResolvers) >= MaxResolverEntries {
-			break
-		}
-		resolverIP := HandleResolverLine(scanner.Text())
-		if resolverIP == "" {
+		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
-		systemResolvers = append(systemResolvers, net.JoinHostPort(resolverIP, "53"))
+
+		if metafiles.IsComment(line) {
+			continue
+		}
+
+		if metafiles.HasComment(line) {
+			commentSplit := strings.Split(line, metafiles.CommentChar)
+			line = commentSplit[0]
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		switch fields[0] {
+		case "nameserver":
+			if maxResolverEntries != -1 && len(config.Resolvers) >= maxResolverEntries {
+				continue
+			}
+
+			resolverIP := HandleResolverLine(line)
+			if resolverIP == "" {
+				continue
+			}
+
+			config.Resolvers = append(config.Resolvers, net.JoinHostPort(resolverIP, "53"))
+		case "search":
+			if len(fields) > 1 {
+				config.SearchDomains = append(config.SearchDomains, fields[1:]...)
+			}
+		case "domain":
+			// per resolv.conf(5), domain is used when search is absent
+			if len(config.SearchDomains) == 0 && len(fields) > 1 {
+				config.SearchDomains = append(config.SearchDomains, fields[1])
+			}
+		case "options":
+			for _, opt := range fields[1:] {
+				if after, ok := strings.CutPrefix(opt, "ndots:"); ok {
+					value := after
+					if nd, err := strconv.Atoi(value); err == nil && nd > 0 {
+						config.Ndots = nd
+					}
+				}
+			}
+		}
 	}
-	return systemResolvers, nil
+
+	config.SearchDomains = dedupeStrings(config.SearchDomains)
+
+	return config, nil
 }
 
 // HandleLine a resolver file line
@@ -81,4 +150,24 @@ func HandleResolverLine(raw string) (ip string) {
 	}
 
 	return ip
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(values))
+
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+
+		if _, ok := seen[v]; ok {
+			continue
+		}
+
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+
+	return out
 }

--- a/fastdialer/resolverfile_test.go
+++ b/fastdialer/resolverfile_test.go
@@ -1,0 +1,187 @@
+package fastdialer
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/projectdiscovery/retryabledns"
+	"github.com/stretchr/testify/require"
+)
+
+func writeResolverFile(t *testing.T, content string) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "resolv.conf")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return path
+}
+
+func TestLoadResolverFile_ParsesResolversSearchAndNdots(t *testing.T) {
+	resolvPath := writeResolverFile(t, `
+# comment line
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+search example.com corp.local example.com
+domain should.not.be.used
+options ndots:2
+`)
+
+	t.Setenv("RESOLVERS_PATH", resolvPath)
+	opts := Options{Ndots: 5, MaxResolverEntries: 1}
+	config, err := loadResolverFile(opts)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"1.1.1.1:53"}, config.Resolvers, "respect MaxResolverEntries limit")
+	require.Equal(t, []string{"example.com", "corp.local"}, config.SearchDomains, "dedupe and preserve order")
+	require.Equal(t, 2, config.Ndots, "ndots option should override default/options value")
+}
+
+func TestLoadResolverFile_UsesDomainWhenSearchMissing(t *testing.T) {
+	resolvPath := writeResolverFile(t, `
+nameserver 9.9.9.9
+domain example.org
+`)
+
+	t.Setenv("RESOLVERS_PATH", resolvPath)
+	opts := Options{Ndots: 1, MaxResolverEntries: 10}
+	config, err := loadResolverFile(opts)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"9.9.9.9:53"}, config.Resolvers)
+	require.Equal(t, []string{"example.org"}, config.SearchDomains)
+	require.Equal(t, 1, config.Ndots)
+}
+
+type mockDNS struct {
+	answers map[string]string
+	queries []string
+	mu      sync.Mutex
+}
+
+func (m *mockDNS) handler(w dns.ResponseWriter, r *dns.Msg) {
+	msg := new(dns.Msg)
+	msg.SetReply(r)
+	if len(r.Question) == 0 {
+		_ = w.WriteMsg(msg)
+		return
+	}
+
+	q := r.Question[0]
+	name := dns.CanonicalName(q.Name)
+	trimmed := name[:len(name)-1] // strip trailing dot
+
+	m.mu.Lock()
+	m.queries = append(m.queries, trimmed)
+	m.mu.Unlock()
+
+	if ip, ok := m.answers[trimmed]; ok {
+		rr, _ := dns.NewRR(fmt.Sprintf("%s A %s", name, ip))
+		msg.Answer = append(msg.Answer, rr)
+	} else {
+		msg.Rcode = dns.RcodeNameError
+	}
+
+	_ = w.WriteMsg(msg)
+}
+
+func startMockDNSServer(t *testing.T, answers map[string]string) (addr string, mock *mockDNS, shutdown func()) {
+	t.Helper()
+
+	m := &mockDNS{answers: answers}
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{PacketConn: pc, Handler: dns.HandlerFunc(m.handler)}
+	done := make(chan struct{})
+
+	go func() {
+		_ = srv.ActivateAndServe()
+		close(done)
+	}()
+
+	shutdown = func() {
+		_ = srv.Shutdown()
+		_ = pc.Close()
+		<-done
+	}
+
+	return pc.LocalAddr().String(), m, shutdown
+}
+
+func newTestDNSClient(t *testing.T, resolver string) *retryabledns.Client {
+	t.Helper()
+
+	client, err := retryabledns.NewWithOptions(retryabledns.Options{
+		BaseResolvers: []string{resolver},
+		MaxRetries:    1,
+		Timeout:       2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	return client
+}
+
+func TestResolveWithSearch_UsesSearchDomainsAndNdots(t *testing.T) {
+	t.Parallel()
+
+	answers := map[string]string{
+		"short.example.com": "192.0.2.10",
+		"a.b.example.com":   "192.0.2.20",
+		"foo.bar":           "192.0.2.30",
+	}
+
+	resolverAddr, mock, shutdown := startMockDNSServer(t, answers)
+	defer shutdown()
+
+	client := newTestDNSClient(t, resolverAddr)
+	d := &Dialer{
+		dnsclient:     client,
+		searchDomains: []string{"example.com", "svc.local"},
+		ndots:         1,
+		options:       &Options{EnableFallback: false},
+	}
+
+	data, err := d.resolveWithSearch("short")
+	require.NoError(t, err)
+	require.Equal(t, []string{"192.0.2.10"}, data.A)
+
+	// For ndots=1, a name with a dot should be tried as-is first.
+	d.ndots = 1
+	mock.mu.Lock()
+	mock.queries = nil
+	mock.mu.Unlock()
+
+	data, err = d.resolveWithSearch("a.b")
+	require.NoError(t, err)
+	require.Equal(t, []string{"192.0.2.20"}, data.A)
+
+	// Ensure query order: absolute first, then search expansion.
+	mock.mu.Lock()
+	queriesCopy := dedupeStrings(mock.queries)
+	mock.mu.Unlock()
+	require.Equal(t, []string{"a.b", "a.b.example.com"}, queriesCopy)
+
+	// Trailing dot skips search-domain expansion.
+	mock.mu.Lock()
+	mock.queries = nil
+	mock.mu.Unlock()
+
+	data, err = d.resolveWithSearch("foo.bar.")
+	require.NoError(t, err)
+	require.Equal(t, []string{"192.0.2.30"}, data.A)
+
+	mock.mu.Lock()
+	queriesCopy = dedupeStrings(mock.queries)
+	mock.mu.Unlock()
+
+	require.Equal(t, []string{"foo.bar"}, queriesCopy)
+}


### PR DESCRIPTION
Implement DNS resolution with `search` domains and
`ndots` from system resolver config, including
fallback to syscall when enabled.

Changes:
* Add options for `MaxResolverEntries` and `Ndots`,
  with defaults centralized. This deprecates old
  `MaxResolverEntries` var.
* Add comprehensive tests for resolver file
  parsing and search resolution.