### PR TITLE
Fixed possible fastdialer datarace, usually masked under low concurrency

### DIFF
--- a/fastdialer/dialer_private.go
+++ b/fastdialer/dialer_private.go
@@ -123,7 +123,8 @@ func (d *Dialer) dial(ctx context.Context, opts *dialOptions) (conn net.Conn, er
 			if err != nil || len(data.A)+len(data.AAAA) == 0 {
 				return nil, NoAddressFoundError
 			}
-			IPS = append(IPS, append(data.A, data.AAAA...)...)
+			IPS = append(IPS, data.A...)
+			IPS = append(IPS, data.AAAA...)
 		}
 
 		filteredIPs := []string{}


### PR DESCRIPTION
  ## What
  Fix a data race in fastdialer DNS result handling.
  `Dialer.dial` previously combined cached A and AAAA records with:
  ```go
  append(data.A, data.AAAA...)
  ```
 
  ## Why
  Because `data.A` comes from cached DNS data, this can mutate the cached slice backing array when it has
  spare capacity. Concurrent dial attempts for the same hostname can then race while reading/writing the
  shared DNS record slice.
  This change appends A and AAAA records separately into the local `IPS` slice, preserving behavior while
  avoiding mutation of cached DNS data.
 
  ## Verification
  - Reproduced with Go race detector through nuclei SDK concurrent HTTP execution.
  - Confirmed the race no longer appears after the patch.
  - Ran targeted package tests/builds successfully.